### PR TITLE
created basic dependency injection example

### DIFF
--- a/examples/zelda-health-bar/config/vite.config.js
+++ b/examples/zelda-health-bar/config/vite.config.js
@@ -9,7 +9,8 @@ export default defineConfig({
       },
       input: {
         main: 'index.html',
-        interSceneExample: 'inter-scene-communication.html'
+        interSceneExample: 'inter-scene-communication.html',
+        dependencyInjectionExample: 'simple-dependency-injection.html'
       }
     },
   },

--- a/examples/zelda-health-bar/simple-dependency-injection.html
+++ b/examples/zelda-health-bar/simple-dependency-injection.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>Phaser 3 - Zelda Health Bar - Simple Dependency Injection</title>
+		<style>
+      html,
+      body,
+      .container {
+        margin: 0px;
+        height: 100vh;
+        width: 100vw;
+        overflow: hidden;
+        background: #d7d7d7;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+    </style>
+	</head>
+	<body>
+		<div class="container" id="game-container">
+      <h1>Phaser 3 Zelda Health Bar</h1>
+      <h4>Click on the game to modify the health!</h4>
+    </div>
+		<script type="module" src="/src/simple-dependency-injection/main.ts"></script>
+	</body>
+</html>

--- a/examples/zelda-health-bar/src/simple-dependency-injection/components/events.ts
+++ b/examples/zelda-health-bar/src/simple-dependency-injection/components/events.ts
@@ -1,0 +1,5 @@
+export const HEALTH_EVENTS = {
+  LOSE_HEALTH: 'LOSE_HEALTH',
+} as const;
+
+export const customEmitter = new Phaser.Events.EventEmitter();

--- a/examples/zelda-health-bar/src/simple-dependency-injection/components/health.ts
+++ b/examples/zelda-health-bar/src/simple-dependency-injection/components/health.ts
@@ -1,0 +1,31 @@
+import { HEALTH_EVENTS } from './events';
+
+export default class Health {
+  #customEventEmitter: Phaser.Events.EventEmitter;
+  #currentHealth: number;
+  #maxHealth: number;
+
+  constructor(customEventEmitter: Phaser.Events.EventEmitter) {
+    this.#currentHealth = 6;
+    this.#maxHealth = 6;
+    this.#customEventEmitter = customEventEmitter;
+  }
+
+  get maxHealth(): number {
+    return this.#maxHealth;
+  }
+
+  get currentHealth(): number {
+    return this.#currentHealth;
+  }
+
+  public loseHealth(): void {
+    if (this.#currentHealth === 0) {
+      return;
+    }
+
+    this.#currentHealth -= 1;
+    // emit event with health now and previous health value
+    this.#customEventEmitter.emit(HEALTH_EVENTS.LOSE_HEALTH, this.#currentHealth, this.#currentHealth + 1);
+  }
+}

--- a/examples/zelda-health-bar/src/simple-dependency-injection/main.ts
+++ b/examples/zelda-health-bar/src/simple-dependency-injection/main.ts
@@ -1,0 +1,23 @@
+import Phaser from 'phaser';
+import { Ui } from './scenes/ui';
+import { Game } from './scenes/game';
+import Health from './components/health';
+
+const gameConfig: Phaser.Types.Core.GameConfig = {
+  type: Phaser.CANVAS,
+  pixelArt: true,
+  scale: {
+    parent: 'game-container',
+    width: 800,
+    height: 600,
+  },
+  backgroundColor: '#5c5b5b',
+};
+
+const game = new Phaser.Game(gameConfig);
+const customEmitter = new Phaser.Events.EventEmitter();
+const customHealthComponent = new Health(customEmitter);
+
+game.scene.add('Game', new Game(customHealthComponent));
+game.scene.add('Ui', new Ui(customEmitter, customHealthComponent));
+game.scene.start('Game');

--- a/examples/zelda-health-bar/src/simple-dependency-injection/scenes/game.ts
+++ b/examples/zelda-health-bar/src/simple-dependency-injection/scenes/game.ts
@@ -1,0 +1,16 @@
+import Health from '../components/health';
+
+export class Game extends Phaser.Scene {
+  #health: Health;
+
+  constructor(health: Health) {
+    super({ key: 'Game', active: true });
+    this.#health = health;
+  }
+
+  create(): void {
+    this.input.on(Phaser.Input.Events.POINTER_DOWN as string, () => {
+      this.#health.loseHealth();
+    });
+  }
+}

--- a/examples/zelda-health-bar/src/simple-dependency-injection/scenes/ui.ts
+++ b/examples/zelda-health-bar/src/simple-dependency-injection/scenes/ui.ts
@@ -1,0 +1,62 @@
+import { HEALTH_EVENTS } from '../components/events';
+import Health from '../components/health';
+
+const ASSET_KEY = 'ASSET_KEY';
+
+const HEALTH_ANIMATIONS = {
+  LOSE_FIRST_HALF: 'LOSE_FIRST_HALF',
+  LOSE_SECOND_HALF: 'LOSE_SECOND_HALF',
+} as const;
+
+export class Ui extends Phaser.Scene {
+  #customEventEmitter: Phaser.Events.EventEmitter;
+  #health: Health;
+
+  constructor(emitter: Phaser.Events.EventEmitter, health: Health) {
+    super({ key: 'Ui', active: true });
+    this.#customEventEmitter = emitter;
+    this.#health = health;
+  }
+
+  preload(): void {
+    this.load.spritesheet(ASSET_KEY, 'assets/images/heart.png', {
+      frameWidth: 7,
+      frameHeight: 7,
+    });
+  }
+
+  create(): void {
+    this.anims.create({
+      key: HEALTH_ANIMATIONS.LOSE_FIRST_HALF,
+      frames: this.anims.generateFrameNumbers(ASSET_KEY, { start: 0, end: 2 }),
+      frameRate: 10,
+    });
+
+    this.anims.create({
+      key: HEALTH_ANIMATIONS.LOSE_SECOND_HALF,
+      frames: this.anims.generateFrameNumbers(ASSET_KEY, { start: 2, end: 4 }),
+      frameRate: 10,
+    });
+
+    const numberOfHearts = Math.round(this.#health.maxHealth / 2);
+    const hearts: Phaser.GameObjects.Sprite[] = [];
+    for (let i = 0; i < numberOfHearts; i++) {
+      const heart = this.add
+        .sprite(10 + i * 63, 10, ASSET_KEY, 0)
+        .setScale(8)
+        .setOrigin(0);
+      hearts.push(heart);
+    }
+
+    this.#customEventEmitter.on(HEALTH_EVENTS.LOSE_HEALTH, (newHealth, prevHealth) => {
+      console.log('event received', newHealth, prevHealth);
+      const heartIndex = Math.round(prevHealth / 2) - 1;
+      const isHalfHeart = prevHealth % 2 === 1;
+      if (isHalfHeart) {
+        hearts[heartIndex].play(HEALTH_ANIMATIONS.LOSE_SECOND_HALF);
+      } else {
+        hearts[heartIndex].play(HEALTH_ANIMATIONS.LOSE_FIRST_HALF);
+      }
+    });
+  }
+}


### PR DESCRIPTION
Created a basic example of how you can inject dependencies into a custom Phaser Scene class. In this example, I extended the current zelda health bar example to inject the health and custom event emitter into the various scenes, instead of having all of these components depend on one and another.